### PR TITLE
Add helper to reverse field name

### DIFF
--- a/tests/testapp/test_fields.py
+++ b/tests/testapp/test_fields.py
@@ -8,7 +8,7 @@ from django.forms.models import modelform_factory
 from django.test import Client, TestCase
 from django.utils.translation import deactivate_all, override
 
-from translated_fields.utils import language_code_formfield_callback
+from translated_fields.utils import language_code_formfield_callback, reverse_field
 
 from .models import (
     CustomLanguagesModel,
@@ -184,3 +184,8 @@ class Test(TestCase):
 
         self.assertIn("Name [en]:", result)
         self.assertIn("Name [de]:", result)
+
+    def test_reverse_field(self):
+        self.assertListEqual(["name_en", "name_de"], reverse_field("name"))
+        self.assertListEqual(["name_en"], reverse_field("name", exclude=["de"]))
+        self.assertListEqual(["name_es"], reverse_field("name", languages=["es"]))

--- a/translated_fields/utils.py
+++ b/translated_fields/utils.py
@@ -30,3 +30,28 @@ def language_code_formfield_callback(db_field, **kwargs):
     if language_code:
         kwargs["label"] = "%s [%s]" % (capfirst(db_field.verbose_name), language_code)
     return db_field.formfield(**kwargs)
+
+
+def reverse_field(field_name, languages=None, exclude=[]):
+    """Reverse a field name to list the field with all the languages
+
+    Args:
+        field_name (str): the field to be reversed without language codes.
+        languages (list, optional): Reverse only on the provided
+            language codes. Defaults to the languages defined in the settings.
+        exclude (list, optional): Ignore language codes in this list.
+
+    Examples:
+
+        >>> get_field_names("name", languages=["en", "es"])
+        ["name_en", "name_es"]
+
+    Returns:
+        A list of field names with appended language codes.
+
+    """
+    if not languages:
+        languages = (l[0] for l in settings.LANGUAGES)
+    return [
+        "{0}_{1}".format(field_name, lang) for lang in languages if lang not in exclude
+    ]


### PR DESCRIPTION
I didn't want to expose all the translations through Tastypie, but that requires putting the field for every translation
```
class CategoryResource(ModelResource):
    class Meta:
        queryset = Category.objects.all()
        excludes = ["name_en", "name_nl", "name_fr", "name_de"]
```
I didn't want to maintain all the possible language codes that might be added in the future. So, I created this helper, that I believe might have a place here.

```
class CategoryResource(ModelResource):
    class Meta:
        queryset = Category.objects.all()
        excludes = reverse_field('name')
```