### PR TITLE
Amend docs to find fields attribute better

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,25 @@ acts as a property for the current language's field:
         assert question.question == "Wie geht es Dir?"
 
     with override("fr"):
-        question.question = "Comment vas-tu?"
+        assert question.question = "Comment vas-tu?"
 
     assert question.question_fr == "Comment vas-tu?"
 
+``TranslatedField`` has a ``fields`` attribute that returns a list of all
+the language fields created. 
+
+.. code-block:: python
+
+    answer = Question(
+        answer_en="Very well!",
+        answer_de="Gut!",
+        answer_fr="Ça va bien!"
+    )
+
+    assert answer.answer.fields == ["answer_en", "answer_de", "answer_fr"]
+
+For more attributes look at the *``TranslatedField`` instance API* 
+section below.
 
 Changing field attributes per language
 ======================================


### PR DESCRIPTION
Continuation of #11 

It's the first time I write documentation in .rst files and didn't know how to add a hyperlink to the API section below.
@matthiask maybe you know?